### PR TITLE
Fix code scanning alert no. 20: Cross-site scripting

### DIFF
--- a/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
+++ b/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
@@ -5,6 +5,7 @@ using System.Web;
 using System.Data;
 using OWASP.WebGoat.NET.App_Code;
 using OWASP.WebGoat.NET.App_Code.DB;
+using System.Net;
 
 namespace OWASP.WebGoat.NET.WebGoatCoins
 {
@@ -23,9 +24,10 @@ namespace OWASP.WebGoat.NET.WebGoatCoins
             //context.Response.Write("Hello World");
 
             string query = context.Request["query"];
+            string encodedQuery = WebUtility.HtmlEncode(query);
             
-            DataSet ds = du.GetCustomerEmails(query);
-            string json = Encoder.ToJSONSAutocompleteString(query, ds.Tables[0]);
+            DataSet ds = du.GetCustomerEmails(encodedQuery);
+            string json = Encoder.ToJSONSAutocompleteString(encodedQuery, ds.Tables[0]);
 
             if (json != null && json.Length > 0)
             {


### PR DESCRIPTION
Fixes [https://github.com/CalinL/advanced-security-demo-csharp/security/code-scanning/20](https://github.com/CalinL/advanced-security-demo-csharp/security/code-scanning/20)

To fix the cross-site scripting vulnerability, we need to ensure that the user-provided input (`query`) is properly sanitized before being included in the `json` string. We can use the `System.Net.WebUtility.HtmlEncode` method to encode the `query` parameter, which will prevent any malicious scripts from being executed.

1. Import the `System.Net` namespace to use the `WebUtility.HtmlEncode` method.
2. Encode the `query` parameter using `WebUtility.HtmlEncode` before passing it to the `Encoder.ToJSONSAutocompleteString` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
